### PR TITLE
Improve support for variable length messages

### DIFF
--- a/arlo/messages.py
+++ b/arlo/messages.py
@@ -35,16 +35,6 @@ class Message:
         else:
             return None
 
-    @staticmethod
-    def fromNetworkMessage(data):
-        if data.startswith("L:"):
-            delimiter = data.index(" ")
-            dataLength = int(data[2:delimiter])
-            json_data = data[delimiter+1:delimiter+1+dataLength]
-            return Message(json.loads(json_data))
-        else:
-            return None
-
 # ID is an incrementing number
 #FROM CAMERA
 REGISTRATION = {

--- a/arlo/socket.py
+++ b/arlo/socket.py
@@ -1,0 +1,40 @@
+import socket
+import json
+
+from arlo.messages import Message
+
+class ArloSocket:
+
+    def __init__(self, sock=None):
+        if sock is None:
+            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        else:
+            self.sock = sock
+
+    def connect(self, host, port):
+        self.sock.connect((host, port))
+
+    def send(self, message):
+        self.sock.sendall(message.toNetworkMessage())
+
+    def receive(self):
+        data = self.sock.recv(1024).decode(encoding="utf-8")
+        if data.startswith("L:"):
+            delimiter = data.index(" ")
+            dataLength = int(data[2:delimiter])
+            json_data = data[delimiter+1:delimiter+1+dataLength]
+        else:
+            return None
+        read = len(json_data)
+        while read < dataLength:
+            to_read = min(dataLength - read, 1024)
+            chunk = self.sock.recv(to_read)
+            if chunk == b'':
+                raise RuntimeError("socket connection broken")
+            chunk_str = chunk.decode(encoding="utf-8")
+            json_data += chunk_str
+            read = read + len(chunk_str)
+        return Message(json.loads(json_data))
+
+    def close(self):
+        self.sock.close()


### PR DESCRIPTION
On my system with Jetson TX1 and Arlo Ultra, `recv()` sometimes returns a cropped message, no matter what buffer size I specify.
This PR adds a class that takes care of reading the message by first reading the length of the message from a first call to `recv()`, then repeatedly calling `recv()` until the whole message has been received.