### PR TITLE
Add support for Arlo Ultra & 4K streaming/recording

### DIFF
--- a/api.postman_collection.json
+++ b/api.postman_collection.json
@@ -365,7 +365,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\"duration\":10}",
+					"raw": "{\"duration\":10,\"is4k\":False}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/api/api.py
+++ b/api/api.py
@@ -133,7 +133,7 @@ def request_record(serial):
     if g.args['duration'] is None:
         flask.abort(400)
     else:
-        result = g.camera.record(g.args['duration'])
+        result = g.camera.record(g.args['duration'], g.args['is4k'])
         return flask.jsonify({"result":result})
 
 @app.route('/camera/<serial>/friendlyname', methods=['POST'])

--- a/arlo/camera.py
+++ b/arlo/camera.py
@@ -87,16 +87,21 @@ class Camera:
         quality = args["quality"].lower()
         if quality == "low":
             ra_params = Message(arlo.messages.RA_PARAMS_LOW_QUALITY)
+            registerSet = Message(arlo.messages.REGISTER_SET_LOW_QUALITY)
         elif quality == "medium":
             ra_params = Message(arlo.messages.RA_PARAMS_MEDIUM_QUALITY)
+            registerSet = Message(arlo.messages.REGISTER_SET_MEDIUM_QUALITY)
         elif quality == "high":
             ra_params = Message(arlo.messages.RA_PARAMS_HIGH_QUALITY)
+            registerSet = Message(arlo.messages.REGISTER_SET_HIGH_QUALITY)
         elif quality == "subscription":
             ra_params = Message(arlo.messages.RA_PARAMS_SUBSCRIPTION_QUALITY)
+            registerSet = Message(arlo.messages.REGISTER_SET_SUBSCRIPTION_QUALITY)
         else:
             return False
 
-        return self.send_message(ra_params)
+        return self.send_message(ra_params) and self.send_message(registerSet)
+
 
     def arm(self,args):
         register_set = Message(arlo.messages.REGISTER_SET)
@@ -140,11 +145,15 @@ class Camera:
         register_set['AudioSpkrEnable'] = enabled
         return self.send_message(register_set)
 
-    def record(self, duration):
+    def record(self, duration, is4k):
         self.status_request() # Cameras tend to be unresponsive so send a status request to wake up
         timestr = time.strftime("%Y%m%d-%H%M%S")
         path = f"/tmp/{self.serial_number}{timestr}-user.mpg", duration
-        recorder = Recorder(self.ip, f"/tmp/{self.serial_number}_{timestr}_user.mpg", duration)
+        if is4k:
+            addr = f'{self.ip}:555'
+        else:
+            addr = f'{self.ip}:554'
+        recorder = Recorder(addr, path, duration)
         recorder.run()
         return path
 

--- a/arlo/messages.py
+++ b/arlo/messages.py
@@ -466,6 +466,15 @@ RA_PARAMS_SUBSCRIPTION_QUALITY = {
                 "targetbps": 10240000,
                 "cbrbps": 10240000
             },
+            "360p":{
+                "minbps":51200,
+                "maxbps":512000,
+                "minQP":24,
+                "maxQP":38,
+                "vbr":True,
+                "targetbps":409600,
+                "cbrbps":409600
+                },
             "480p":{
                 "minbps":51200,
                 "maxbps":614400,

--- a/arlo/messages.py
+++ b/arlo/messages.py
@@ -298,6 +298,15 @@ RA_PARAMS_LOW_QUALITY = {
                 "targetbps":409600,
                 "cbrbps":409600
                 },
+            "4K": {
+                "minbps": 307200,
+                "maxbps": 2048000,
+                "minQP": 26,
+                "maxQP": 38,
+                "vbr": True,
+                "targetbps": 1024000,
+                "cbrbps": 1024000
+            },
             "360p":{
                 "minbps":51200,
                 "maxbps":307200,
@@ -341,6 +350,15 @@ RA_PARAMS_MEDIUM_QUALITY = {
                 "targetbps":512000,
                 "cbrbps":512000
                 },
+            "4K": {
+                "minbps": 307200,
+                "maxbps": 3072000,
+                "minQP": 26,
+                "maxQP": 38,
+                "vbr": True,
+                "targetbps": 1536000,
+                "cbrbps": 2048000
+            },
             "360p":{
                 "minbps":51200,
                 "maxbps":409600,
@@ -384,6 +402,15 @@ RA_PARAMS_HIGH_QUALITY = {
                 "targetbps":614400,
                 "cbrbps":614400
                 },
+            "4K": {
+                "minbps": 307200,
+                "maxbps": 5120000,
+                "minQP": 26,
+                "maxQP": 38,
+                "vbr": True,
+                "targetbps": 3072000,
+                "cbrbps": 3072000
+            },
             "360p":{
                 "minbps":51200,
                 "maxbps":512000,
@@ -427,15 +454,18 @@ RA_PARAMS_SUBSCRIPTION_QUALITY = {
                 "targetbps":1024000,
                 "cbrbps":1024000
                 },
-            "360p":{
-                "minbps":51200,
-                "maxbps":512000,
-                "minQP":24,
-                "maxQP":38,
-                "vbr":True,
-                "targetbps":409600,
-                "cbrbps":409600
-                },
+            # I'm not sure what subscription quality is
+            # but I'm using it as a playground to see
+            # what's the highest quality video I can get
+            "4K": {
+                "minbps": 307200,
+                "maxbps": 10240000,
+                "minQP": 1,
+                "maxQP": 1,
+                "vbr": False,
+                "targetbps": 10240000,
+                "cbrbps": 10240000
+            },
             "480p":{
                 "minbps":51200,
                 "maxbps":614400,
@@ -529,6 +559,50 @@ REGISTER_SET_ARM_AUDIO = {
             }
         }
 
+REGISTER_SET_LOW_QUALITY = {
+    "Type":"registerSet",
+    "ID":-1,
+    "SetValues":{
+        "VideoOutputResolution": "720p",
+        "VideoTargetBitrate": 400,
+        "HEVCVideoOutputResolution": "2160p",
+        "HEVCVideoTargetBitrate": 1000,
+    }
+}
+
+REGISTER_SET_MEDIUM_QUALITY = {
+    "Type":"registerSet",
+    "ID":-1,
+    "SetValues":{
+        "VideoOutputResolution": "1080p",
+        "VideoTargetBitrate": 600,
+        "HEVCVideoOutputResolution": "2160p",
+        "HEVCVideoTargetBitrate": 1500,
+    }
+}
+
+REGISTER_SET_HIGH_QUALITY = {
+    "Type":"registerSet",
+    "ID":-1,
+    "SetValues":{
+        "VideoOutputResolution": "1080p",
+        "VideoTargetBitrate": 1250,
+        "HEVCVideoOutputResolution": "2160p",
+        "HEVCVideoTargetBitrate": 3000,
+    }
+}
+
+REGISTER_SET_SUBSCRIPTION_QUALITY = {
+    "Type":"registerSet",
+    "ID":-1,
+    "SetValues":{
+        "VideoOutputResolution": "1080p",
+        "VideoTargetBitrate": 1250,
+        "HEVCVideoOutputResolution": "2160p",
+        "HEVCVideoTargetBitrate": 6000,
+    }
+}
+
 REGISTER_SET_INITIAL = {
         "Type":"registerSet",
         "ID":-1,
@@ -566,6 +640,52 @@ REGISTER_SET_INITIAL = {
                 "DefaultMotionStreamTimeLimit":10
                 }
         }
+
+# Register set specific to the Arlo Ultra
+REGISTER_SET_INITIAL_ULTRA = {
+        "Type":"registerSet",
+        "ID":-1,
+        "SetValues":{
+            "VideoExposureCompensation": 0,
+            "VideoMirror": False,
+            "VideoFlip": False,
+            "VideoWindowStartX": 0,
+            "VideoWindowStartY": 0,
+            "VideoWindowEndX": 1280,
+            "VideoWindowEndY": 720,
+            "MaxMissedBeaconTime": 10,
+            "MaxStreamTimeLimit": 1800,
+            "VideoAntiFlickerRate": 50,
+            "WifiCountryCode": "FR",
+            "NightVisionMode": False,
+            "IRLedState": "off",
+            "IRCutState": "engaged",
+            "HdrControl": "auto",
+            "MaxUserStreamTimeLimit": 1800,
+            "MaxMotionStreamTimeLimit": 120,
+            "VideoMode": "superWide",
+            "JPEGOutputResolution": "360p",
+            "EpochBsTime": 1610925182,
+            "ChargeNotificationLed": 1,
+            "AudioMicAGC": 0,
+            "NightModeLightSourceAlert": 1,
+            "SpotlightModeAlert": 0,
+            "SpotlightIntensityAlert": 100,
+            "NightModeGrey": 0,
+            "AudioMicWNS": 0,
+            "VideoSmartZoom": "off",
+            "VideoOutputResolution": "1080p",
+            "VideoTargetBitrate": 1250,
+            "HEVCVideoOutputResolution": "2160p",
+            "HEVCVideoTargetBitrate": 3000,
+            "MaxSensorRequired": True,
+            "Audio0EncodeFormat": 0,
+            "Audio1EncodeFormat": 1,
+            "ArloSmart": True,
+            "CvrModeEnabled": False,
+            "AlertBackoffTime": 0
+        }
+}
 
 REGISTER_SET_INITIAL_SUBSCRIPTION = {
         "Type":"registerSet",

--- a/server.py
+++ b/server.py
@@ -59,7 +59,10 @@ class ConnectionThread(threading.Thread):
                         camera.registration = msg
                     camera.persist()
                     s_print(f"<[{self.ip}][{msg['ID']}] Registration from {msg['SystemSerialNumber']} - {camera.hostname}")
-                    registerSet = Message(arlo.messages.REGISTER_SET_INITIAL)
+                    if msg['SystemModelNumber'] ==  'VMC5040':
+                        registerSet = Message(arlo.messages.REGISTER_SET_INITIAL_ULTRA)
+                    else:
+                        registerSet = Message(arlo.messages.REGISTER_SET_INITIAL)
                     camera.send_message(registerSet)
                 elif (msg['Type'] == "status"):
                     s_print(f"<[{self.ip}][{msg['ID']}] Status from {msg['SystemSerialNumber']}")


### PR DESCRIPTION
The Arlo Ultras have an additional RTSP endpoint for 4k streaming at `rtsp://<camera_ip>:555/live`.
This PR adds some options specific to the Arlo Ultra (VMC5040) and the option to record in 4k.
I'm hoping cameras that don't support 4k will simply ignore the 4k settings.