### PR TITLE
patched to call stop func on recorder object

### DIFF
--- a/server.py
+++ b/server.py
@@ -81,7 +81,7 @@ class ConnectionThread(threading.Thread):
                        recorder = Recorder(self.ip, filename, MOTION_RECORDING_TIMEOUT)
                        with recorder_lock:
                            if self.ip in recorders:
-                               recorder[self.ip].stop()
+                               recorders[self.ip].stop()
                            recorders[self.ip] = recorder
                        recorder.run()
                        webhook_manager.motion_detected(camera.ip,camera.friendly_name,camera.hostname,camera.serial_number,msg['PIRMotion']['zones'],filename)


### PR DESCRIPTION
i've just updated this line so the `stop` method can be actually called.

multiple motions are trggering mpgs to be recorded to `RecordingBasePath` after the patch.
obviously with `RecordOnMotionAlert: true` set in config.yaml and making the below call to (motion) arm the camera!

```
curl -X POST localhost:5000/camera/${SERIAL_ID}/arm -H 'Content-Type: application/json' -d '{"PIRTargetState":"Armed","VideoMotionEstimationEnable":false,"AudioTargetState":"Disarmed"}'
```



again, this is some amazing work! :pray: